### PR TITLE
Stagger process spawning

### DIFF
--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -154,7 +154,9 @@ class ShardingManager {
 
       processes.add(spawned);
 
-      await Future.delayed(individualConnectionDelay * (lastIndex - totalSpawned));
+      if (lastIndex != shardIds.length) {
+        await Future.delayed(individualConnectionDelay * (lastIndex - totalSpawned));
+      }
     }
 
     _logger.info('Successfully started ${processes.length} processes, totalling $_totalShards shards');

--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -108,8 +108,35 @@ class ShardingManager {
     return recommended;
   }
 
+  Future<int> _getMaxConcurrency() async {
+    if (token == null) {
+      return 1;
+    }
+
+    INyxx client = NyxxFactory.createNyxxRest(token!, GatewayIntents.none, Snowflake.zero());
+
+    await client.connect();
+
+    IHttpResponse gatewayBot = await (client.httpEndpoints as HttpEndpoints).getGatewayBot();
+
+    if (gatewayBot is IHttpResponseError) {
+      throw ShardingError('Cannot connect to Discord to get max connection concurrency: [$gatewayBot]');
+    }
+
+    await client.dispose();
+
+    int maxConcurrency = (gatewayBot as IHttpResponseSucess).jsonBody['session_start_limit']['max_concurrency'] as int;
+
+    _logger.info('Got max concurrency: $maxConcurrency');
+
+    return maxConcurrency;
+  }
+
   Future<void> _startProcesses() async {
     List<int> shardIds = List.generate(_totalShards!, (id) => id);
+
+    int maxConcurrency = await _getMaxConcurrency();
+    Duration individualConnectionDelay = Duration(milliseconds: (5 * 1000) ~/ maxConcurrency + 1000);
 
     for (int totalSpawned = 0; totalSpawned < _totalShards!; totalSpawned += _shardsPerProcess!) {
       int lastIndex = totalSpawned + _shardsPerProcess!;
@@ -126,6 +153,8 @@ class ShardingManager {
       }
 
       processes.add(spawned);
+
+      await Future.delayed(individualConnectionDelay * (lastIndex - totalSpawned));
     }
 
     _logger.info('Successfully started ${processes.length} processes, totalling $_totalShards shards');


### PR DESCRIPTION
# Description

Adds a timeout between spawning processes, preventing issues with maximum IDENTIFY concurrency in the spawned process.

Closes #5 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
