### PR TITLE
Fix query parameter format and guild count ratelimit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
-## 2.0.0
+## 2.0.0-dev.0.2
+__Bug fixes__:
+- Fixed an issue with ratelimiting when fetching guild counts.
+
+## 2.0.0-dev.0.1
+__Bug fixes__:
+- Fixed an issue with query parameter formatting preventing guild counts from being fetched.
+
+## 2.0.0-dev.0
 __Breaking changes__:
 - Added a new `port` parameter to `ProcessData.spawn`.
 
@@ -10,6 +18,6 @@ __New features__:
 __Bug fixes__:
 - Spawned processes no longer prevent the parent from exiting.
 
-## 1.0.0
+## 0.1.0.0
 
 - Initial version.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 2.0.0
+__Breaking changes__:
+- Added a new `port` parameter to `ProcessData.spawn`.
+
+__New features__:
+- Added a CLI for easier usage of nyxx_sharding. Run `dart pub global activate nyxx_sharding` to enable the CLI and then `nyxx-sharding --help` for more.
+- Added new `maxGuildsPerShard` and `maxGuildsPerProcess` options for spawning processes.
+- Added methods for fetching data across processes. See the docs for `IShardingManager` and `IShardingPlugin` for more.
+
+__Bug fixes__:
+- Spawned processes no longer prevent the parent from exiting.
+
 ## 1.0.0
 
 - Initial version.

--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -405,7 +405,7 @@ class ShardingManager with ShardingServer implements IShardingManager {
 
     int total = 0;
 
-    _logger.fine('Fetching guilds...');
+    _logger.info('Fetching guilds...');
 
     while (true) {
       http.Response response = await http.get(
@@ -432,16 +432,16 @@ class ShardingManager with ShardingServer implements IShardingManager {
         break;
       }
 
-      if (response.headers['X-RateLimit-Remaining'] == '0') {
-        int resetTimestamp = num.parse(response.headers['X-RateLimit-Reset']!).ceil();
+      if (int.parse(response.headers['x-ratelimit-remaining']!) < 2) {
+        int resetTimestamp = num.parse(response.headers['x-ratelimit-reset']!).ceil();
 
-        DateTime resetTime = DateTime.fromMillisecondsSinceEpoch(resetTimestamp);
+        DateTime resetTime = DateTime.fromMillisecondsSinceEpoch(resetTimestamp * 1000);
 
         await Future.delayed(resetTime.difference(DateTime.now()));
       }
     }
 
-    _logger.fine('Found a total of $total guilds');
+    _logger.info('Found a total of $total guilds');
 
     return total;
   }

--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -409,7 +409,7 @@ class ShardingManager with ShardingServer implements IShardingManager {
 
     while (true) {
       http.Response response = await http.get(
-        Uri.parse('https://discord.com/api/users/@me/guilds${after == null ? '' : '&after=$after'}'),
+        Uri.parse('https://discord.com/api/users/@me/guilds${after == null ? '' : '?after=$after'}'),
         headers: {
           'Authorization': 'Bot $token',
         },

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nyxx_sharding
 description: External sharding for nyxx.
-version: 1.0.0
+version: 2.0.0-dev.0
 homepage: https://github.com/nyxx-discord/nyxx_sharding
 repository: https://github.com/nyxx-discord/nyxx_sharding
 documentation: https://nyxx.l7ssha.xyz

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nyxx_sharding
 description: External sharding for nyxx.
-version: 2.0.0-dev.0.1
+version: 2.0.0-dev.0.2
 homepage: https://github.com/nyxx-discord/nyxx_sharding
 repository: https://github.com/nyxx-discord/nyxx_sharding
 documentation: https://nyxx.l7ssha.xyz

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nyxx_sharding
 description: External sharding for nyxx.
-version: 2.0.0-dev.0
+version: 2.0.0-dev.0.1
 homepage: https://github.com/nyxx-discord/nyxx_sharding
 repository: https://github.com/nyxx-discord/nyxx_sharding
 documentation: https://nyxx.l7ssha.xyz


### PR DESCRIPTION
# Description

Fixes an issue with the format of query parameters, as well as an issue with how ratelimiting is handled for fetching the guild count.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
