### PR TITLE
Correctly fetch guild counts

### DIFF
--- a/example/example_client.dart
+++ b/example/example_client.dart
@@ -17,7 +17,7 @@ void main() async {
     options: getOptions(),
   );
 
-  // Register the sharding plugin to allow other processes to query this process about data like memory usage anc cache sizes.
+  // Register the sharding plugin to allow other processes to query this process about data like memory usage and cache sizes.
   // The plugin is also how you can request that data, so you might want to extract it to a variable.
   client.registerPlugin(ShardingPlugin());
 


### PR DESCRIPTION
# Description

Adds more robust code when fetching guild counts to compensate for inaccuracy in the Discord API.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
