### PR TITLE
Add option to use an approximate guild count

### DIFF
--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -401,6 +401,13 @@ class ShardingManager with ShardingServer implements IShardingManager {
       throw ShardingError('Cannot get guild count when token is null');
     }
 
+    if (options.useImpreciseGuildCount) {
+      _logger.info('Fetching guilds using approximation...');
+
+      // Discord seems to recommend 1000 guilds per shard
+      return await _getRecommendedShards() * 1000;
+    }
+
     String? after;
 
     int total = 0;

--- a/lib/src/sharding_options.dart
+++ b/lib/src/sharding_options.dart
@@ -15,9 +15,15 @@ class ShardingOptions {
   /// Generally you will not want to disable this; this option should be used for testing only.
   final bool timeoutSpawn;
 
+  /// Whether to get the guild count using an approximation rather than an exact number.
+  ///
+  /// This will be faster than fetching the exact count.
+  final bool useImpreciseGuildCount;
+
   const ShardingOptions({
     this.redirectOutput = true,
     this.timeoutSpawn = true,
     this.respawnProcesses = true,
+    this.useImpreciseGuildCount = false,
   });
 }


### PR DESCRIPTION
# Description

Adds an option to compute an approximate guild count from recommended shard counts instead of fetching all the guilds the bot is in.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
