### PR TITLE
Add automatic scaling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.0.0-dev.1
+__Bug fixes__
+- Fixed fetching guild count being inconsistent
+
+__New features__
+- Added an `autoScale` option that will automatically scale youru processes & shards according to youur bot's size in realtime.
+
 ## 2.0.0-dev.0.2
 __Bug fixes__:
 - Fixed an issue with ratelimiting when fetching guild counts.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,9 @@
 ## 2.0.0-dev.1
-__Bug fixes__
-- Fixed fetching guild count being inconsistent
-
 __New features__
 - Added an `autoScale` option that will automatically scale youru processes & shards according to youur bot's size in realtime.
+
+__Bug fixes__
+- Fixed fetching guild count being inconsistent
 
 ## 2.0.0-dev.0.2
 __Bug fixes__:

--- a/lib/src/communication/sharding_server.dart
+++ b/lib/src/communication/sharding_server.dart
@@ -23,6 +23,9 @@ mixin ShardingServer implements IShardingManager, IDataProvider {
 
   final Logger _logger = Logger('Sharding Server');
 
+  final StreamController<WebSocket> connectionsController = StreamController.broadcast();
+  Stream<WebSocket> get onConnection => connectionsController.stream;
+
   Future<void> startServer() async {
     _logger.fine('Starting server');
 
@@ -34,6 +37,7 @@ mixin ShardingServer implements IShardingManager, IDataProvider {
       _logger.finer('Got connection to server');
 
       connections.add(socket);
+      connectionsController.add(socket);
 
       StreamSubscription<String> subscription = socket.cast<String>().listen((event) => handleEvent(event, socket));
 

--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -225,15 +225,15 @@ class ShardingManager with ShardingServer implements IShardingManager {
         _providedTotalShards = totalShards,
         _maxGuildsPerShard = maxGuildsPerShard,
         _maxGuildsPerProcess = maxGuildsPerProcess {
-    if (_totalShards != null && _totalShards! < 1) {
+    if (_providedTotalShards != null && _providedTotalShards! < 1) {
       throw ShardingError('Invalid shard count specified: total shard count cannot be below 1');
     }
 
-    if (_numProcesses != null && _numProcesses! < 1) {
+    if (_providedNumProcesses != null && _providedNumProcesses! < 1) {
       throw ShardingError('Invalid process count: total process count cannot be below 1');
     }
 
-    if (_shardsPerProcess != null && _shardsPerProcess! < 1) {
+    if (_providedShardsPerProcess != null && _providedShardsPerProcess! < 1) {
       throw ShardingError('Invalid shard per process count specified: total shards per process cannot be less than 1');
     }
 
@@ -529,7 +529,7 @@ class ShardingManager with ShardingServer implements IShardingManager {
   }
 
   Future<Process> _spawn(List<int> shardIds) async {
-    final spawnedProcess = await processData.spawn(shardIds, _totalShards!, port);
+    final spawnedProcess = await processData.spawn(shardIds, totalShards!, port);
 
     if (options.redirectOutput) {
       spawnedProcess.stdout.transform(utf8.decoder).forEach(stdout.write);

--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'dart:convert';
 import 'dart:io';
 import 'dart:isolate';
@@ -177,11 +178,11 @@ class ShardingManager with ShardingServer implements IShardingManager {
   final ProcessData processData;
 
   @override
-  int? get shardsPerProcess => _shardsPerProcess;
+  int? get shardsPerProcess => _providedShardsPerProcess ?? _shardsPerProcess;
   @override
-  int? get numProcesses => _numProcesses;
+  int? get numProcesses => _providedNumProcesses ?? _numProcesses;
   @override
-  int? get totalShards => _totalShards;
+  int? get totalShards => _providedTotalShards ?? _totalShards;
   @override
   int? get maxGuildsPerShard => _maxGuildsPerShard;
   @override
@@ -192,6 +193,10 @@ class ShardingManager with ShardingServer implements IShardingManager {
   int? _totalShards;
   final int? _maxGuildsPerShard;
   final int? _maxGuildsPerProcess;
+
+  final int? _providedShardsPerProcess;
+  final int? _providedNumProcesses;
+  final int? _providedTotalShards;
 
   @override
   final String? token;
@@ -215,9 +220,9 @@ class ShardingManager with ShardingServer implements IShardingManager {
     int? maxGuildsPerProcess,
     this.token,
     this.options = const ShardingOptions(),
-  })  : _shardsPerProcess = shardsPerProcess,
-        _numProcesses = numProcesses,
-        _totalShards = totalShards,
+  })  : _providedShardsPerProcess = shardsPerProcess,
+        _providedNumProcesses = numProcesses,
+        _providedTotalShards = totalShards,
         _maxGuildsPerShard = maxGuildsPerShard,
         _maxGuildsPerProcess = maxGuildsPerProcess {
     if (_totalShards != null && _totalShards! < 1) {
@@ -271,69 +276,73 @@ class ShardingManager with ShardingServer implements IShardingManager {
     }
 
     await _startProcesses();
+
+    if (options.autoScale) {
+      _startMonitoring();
+    }
   }
 
-  Future<void> _computeShardAndProcessCounts() async {
-    if ([totalShards, numProcesses, shardsPerProcess].where((element) => element != null).length >= 2) {
+  Future<void> _computeShardAndProcessCounts([int? existingGuildCount]) async {
+    if ([_providedTotalShards, _providedNumProcesses, _providedShardsPerProcess].where((element) => element != null).length >= 2) {
       // If two of [totalShards], [numProcesses] or [shardsPerProcess] are given, the third can be calculated with
       // this identity: totalShards = numProcesses * shardsPerProcess
-      if (totalShards != null && numProcesses != null && shardsPerProcess != null) {
+      if (_providedTotalShards != null && _providedNumProcesses != null && _providedShardsPerProcess != null) {
         // If all three are provided, check that the values respect the identity
-        if (totalShards != numProcesses! * shardsPerProcess!) {
+        if (_providedTotalShards != _providedNumProcesses! * _providedShardsPerProcess!) {
           throw ShardingError(
-            'Total shard count ($totalShards) was not equal to product of process count and shards per process ($numProcesses * $shardsPerProcess = ${numProcesses! * shardsPerProcess!})',
+            'Total shard count ($_providedTotalShards) was not equal to product of process count and shards per process ($_providedNumProcesses * $_providedShardsPerProcess = ${_providedNumProcesses! * _providedShardsPerProcess!})',
           );
         }
-      } else if (numProcesses != null && shardsPerProcess != null) {
-        _totalShards = numProcesses! * shardsPerProcess!;
-      } else if (totalShards != null && shardsPerProcess != null) {
-        _numProcesses = (totalShards! / shardsPerProcess!).ceil();
-      } else if (totalShards != null && numProcesses != null) {
-        _shardsPerProcess = (totalShards! / numProcesses!).ceil();
+      } else if (_providedNumProcesses != null && _providedShardsPerProcess != null) {
+        _totalShards = _providedNumProcesses! * _providedShardsPerProcess!;
+      } else if (_providedTotalShards != null && _providedShardsPerProcess != null) {
+        _numProcesses = (_providedTotalShards! / _providedShardsPerProcess!).ceil();
+      } else if (_providedTotalShards != null && _providedNumProcesses != null) {
+        _shardsPerProcess = (_providedTotalShards! / _providedNumProcesses!).ceil();
       }
 
       // Warn about guild limits
-      await _warnGuildLimits();
+      await _warnGuildLimits(existingGuildCount);
     } else {
       // If less than 2 are provided, we need a token as we will need to fetch guild count or recommended shard count.
       if (token == null) {
         throw ShardingError('A token must be provided if less than two of total shards, shards per process or process count are provided');
       }
 
-      if (shardsPerProcess != null) {
+      if (_providedShardsPerProcess != null) {
         // Get [totalShards] and [numProcesses] from the guild limits if we have them
         if (maxGuildsPerShard != null || maxGuildsPerProcess != null) {
-          int guildCount = await _getGuildCount();
+          int guildCount = existingGuildCount ?? await _getGuildCount();
 
           if (maxGuildsPerShard != null) {
             _totalShards = (guildCount / maxGuildsPerShard!).ceil();
-            _numProcesses = (totalShards! / shardsPerProcess!).ceil();
+            _numProcesses = (totalShards! / _providedShardsPerProcess!).ceil();
           } else if (maxGuildsPerProcess != null) {
             _numProcesses = (guildCount / maxGuildsPerProcess!).ceil();
-            _totalShards = numProcesses! * shardsPerProcess!;
+            _totalShards = numProcesses! * _providedShardsPerProcess!;
           }
 
           await _warnGuildLimits(guildCount);
         } else {
           // If there are no guild limits, fall back to fetching the recommended shard count from Discord
           _totalShards = await _getRecommendedShards();
-          _numProcesses = (totalShards! / shardsPerProcess!).ceil();
+          _numProcesses = (totalShards! / _providedShardsPerProcess!).ceil();
         }
-      } else if (numProcesses != null) {
-        int guildCount = await _getGuildCount();
+      } else if (_providedNumProcesses != null) {
+        int guildCount = existingGuildCount ?? await _getGuildCount();
 
         // We can't use maxGuildPerProcess since we already have a number of processes
         if (maxGuildsPerShard != null) {
           _totalShards = (guildCount / maxGuildsPerShard!).ceil();
-          _shardsPerProcess = (totalShards! / numProcesses!).ceil();
+          _shardsPerProcess = (totalShards! / _providedNumProcesses!).ceil();
         } else {
           _totalShards = await _getRecommendedShards();
-          _shardsPerProcess = (totalShards! / numProcesses!).ceil();
+          _shardsPerProcess = (totalShards! / _providedNumProcesses!).ceil();
         }
 
         await _warnGuildLimits(guildCount);
       } else if (maxGuildsPerProcess != null) {
-        int guildCount = await _getGuildCount();
+        int guildCount = existingGuildCount ?? await _getGuildCount();
 
         _numProcesses = (guildCount / maxGuildsPerProcess!).ceil();
 
@@ -452,18 +461,12 @@ class ShardingManager with ShardingServer implements IShardingManager {
   Future<void> _startProcesses() async {
     _logger.info('Starting $numProcesses processes, each with $shardsPerProcess shards (for a total of $totalShards)');
 
-    List<int> shardIds = List.generate(_totalShards!, (id) => id);
+    List<int> shardIds = List.generate(totalShards!, (id) => id);
 
-    Duration individualConnectionDelay;
-    if (options.timeoutSpawn) {
-      int maxConcurrency = await _getMaxConcurrency();
-      individualConnectionDelay = Duration(milliseconds: (5 * 1000) ~/ maxConcurrency + 1000);
-    } else {
-      individualConnectionDelay = Duration.zero;
-    }
+    Duration individualConnectionDelay = await _getConnectionDelay();
 
-    for (int totalSpawned = 0; totalSpawned < _totalShards!; totalSpawned += _shardsPerProcess!) {
-      int lastIndex = totalSpawned + _shardsPerProcess!;
+    for (int totalSpawned = 0; totalSpawned < totalShards!; totalSpawned += shardsPerProcess!) {
+      int lastIndex = totalSpawned + shardsPerProcess!;
 
       if (lastIndex > shardIds.length) {
         lastIndex = shardIds.length;
@@ -478,7 +481,16 @@ class ShardingManager with ShardingServer implements IShardingManager {
       }
     }
 
-    _logger.info('Successfully started ${processes.length} processes, totalling $_totalShards shards');
+    _logger.info('Successfully started ${processes.length} processes, totalling $totalShards shards');
+  }
+
+  Future<Duration> _getConnectionDelay() async {
+    if (options.timeoutSpawn) {
+      int maxConcurrency = await _getMaxConcurrency();
+      return Duration(milliseconds: (5 * 1000) ~/ maxConcurrency + 1000);
+    } else {
+      return Duration.zero;
+    }
   }
 
   Future<int> _getMaxConcurrency() async {
@@ -538,6 +550,90 @@ class ShardingManager with ShardingServer implements IShardingManager {
     });
 
     return spawnedProcess;
+  }
+
+  Future<void> _startMonitoring() async {
+    _logger.info('Waiting for all processes to connect to manager...');
+
+    while (connections.length != numProcesses) {
+      Completer<void> nextConnection = Completer();
+
+      StreamSubscription<WebSocket> nextConnectionSubscription = onConnection.listen((event) => nextConnection.complete());
+
+      await nextConnection.future;
+      nextConnectionSubscription.cancel();
+    }
+
+    _logger.info('Starting to monitor processes');
+
+    while (!_exiting) {
+      await Future.delayed(options.autoScaleInterval);
+      await _updateProcesses();
+    }
+  }
+
+  Future<void> _updateProcesses() async {
+    int oldShardsPerProcess = shardsPerProcess!;
+    int oldNumProcesses = numProcesses!;
+    int oldTotalShards = totalShards!;
+
+    _logger.finer('Updating processes...');
+
+    // Use the guild count obtained from the processes themselves instesad of refetching it
+    await _computeShardAndProcessCounts((await getCachedGuilds()).reduce((a, b) => a + b));
+
+    // Restart processes if needed
+    if (oldShardsPerProcess != shardsPerProcess || oldNumProcesses != numProcesses || oldTotalShards != totalShards) {
+      _logger.info('Restarting $numProcesses processes, each with $shardsPerProcess shards (for a total of $totalShards)');
+      _logger.fine('(Previously $oldNumProcesses processes, each with $oldShardsPerProcess shards (for a total of $oldTotalShards))');
+
+      // Prevent processes from restarting
+      _exiting = true;
+
+      List<int> shardIds = List.generate(totalShards!, (i) => i);
+
+      Duration individualConnectionDelay = await _getConnectionDelay();
+
+      List<Process> oldProcesses = List.from(processes);
+
+      for (int totalSpawned = 0; totalSpawned < totalShards!; totalSpawned += shardsPerProcess!) {
+        int lastIndex = totalSpawned + shardsPerProcess!;
+
+        if (lastIndex > shardIds.length) {
+          lastIndex = shardIds.length;
+        }
+
+        // Ensure all processes handling shards we are about to spawn are dead so we don't get single events twice
+        double progress = lastIndex / totalShards!;
+        int progressIndex = (progress * oldProcesses.length).ceil();
+        for (int i = 0; i < progressIndex; i++) {
+          if (oldProcesses[i].kill(ProcessSignal.sigterm)) {
+            _logger.fine('Killing old process #${i + 1} of ${oldProcesses.length}...');
+            await oldProcesses[i].exitCode.timeout(
+              Duration(minutes: 1),
+              onTimeout: () {
+                _logger.warning('Forcefully killing old process #${i + 1} of ${oldProcesses.length} as it did not shutdown gracefully'
+                    ' (did you add CliIntegration to your client?)');
+
+                oldProcesses[i].kill(ProcessSignal.sigkill);
+                return oldProcesses[i].exitCode;
+              },
+            );
+            _logger.info('Killed old process #${i + 1} of ${oldProcesses.length}');
+          }
+        }
+
+        await _spawn(shardIds.sublist(totalSpawned, lastIndex));
+
+        _logger.fine('Spawned new process with shards ${shardIds.sublist(totalSpawned, lastIndex)}');
+
+        if (lastIndex != shardIds.length) {
+          await Future.delayed(individualConnectionDelay * (lastIndex - totalSpawned));
+        }
+      }
+
+      _exiting = false;
+    }
   }
 
   @override

--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -495,9 +495,9 @@ class ShardingManager with ShardingServer implements IShardingManager {
     if (options.timeoutSpawn) {
       int maxConcurrency = await _getMaxConcurrency();
       return Duration(milliseconds: (5 * 1000) ~/ maxConcurrency + 1000);
-    } else {
-      return Duration.zero;
     }
+
+    return Duration.zero;
   }
 
   Future<int> _getMaxConcurrency() async {

--- a/lib/src/sharding_options.dart
+++ b/lib/src/sharding_options.dart
@@ -15,9 +15,21 @@ class ShardingOptions {
   /// Generally you will not want to disable this; this option should be used for testing only.
   final bool timeoutSpawn;
 
+  /// Whether to automatically restart processes when they grow beyond a certain threshold with updated shard and process counts.
+  ///
+  /// This setting requires the child processes to add [IShardingPlugin] to their respective clients.
+  ///
+  /// This setting can cause downtime while the processes restart, so it is disabled by default.
+  final bool autoScale;
+
+  /// The interval at which to check if processes should be restarted, if [autoScale] is `true`.
+  final Duration autoScaleInterval;
+
   const ShardingOptions({
     this.redirectOutput = true,
     this.timeoutSpawn = true,
     this.respawnProcesses = true,
+    this.autoScale = false,
+    this.autoScaleInterval = const Duration(minutes: 15),
   });
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: nyxx_sharding
 description: External sharding for nyxx.
-version: 2.0.0-dev.0.2
+version: 2.0.0-dev.1
 homepage: https://github.com/nyxx-discord/nyxx_sharding
 repository: https://github.com/nyxx-discord/nyxx_sharding
 documentation: https://nyxx.l7ssha.xyz


### PR DESCRIPTION
# Description

Adds an option to automatically scale process & shard counts according to bot size.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have checked my changes haven't lowered code coverage
