### PR TITLE
Fix crashing on windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.1
+__Bug fixes__:
+
+- Fix crash on Windows
+
 ## 2.0.0
 __New features__:
 - Added a CLI for easier usage of nyxx_sharding. Run `dart pub global activate nyxx_sharding` to enable the CLI and then `nyxx-sharding --help` for more.

--- a/lib/src/sharding_manager.dart
+++ b/lib/src/sharding_manager.dart
@@ -266,6 +266,10 @@ class ShardingManager with ShardingServer implements IShardingManager {
     }
 
     for (final signal in [ProcessSignal.sigint, ProcessSignal.sigterm]) {
+      if (Platform.isWindows && signal == ProcessSignal.sigterm) {
+        break;
+      }
+
       signal.watch().listen((event) async {
         _logger.info('Exiting...');
 


### PR DESCRIPTION
# Description
Fix crashing on windows, as it cannot listen for `SIGTERM`

## Connected issues & other potential problems
-/-

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] Ran `dart analyze` or `make analyze` and fixed all issues
- [x] Ran `dart format --set-exit-if-changed -l 160 ./lib` or `make format` and fixed all issues
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked my changes haven't lowered code coverage
